### PR TITLE
Freeze transformers package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cython
 scipy
 xmltodict
 tqdm
-transformers
+transformers==4.5.1
 onnx
 onnxruntime
 prettytable


### PR DESCRIPTION
Latest transformers package (4.9.1) breaks the ROBERTA text encoder during pretraining, so we freeze it at version 4.5.1