### PR TITLE
import CustomCocoDataset from mixed.py instead of clevr.py

### DIFF
--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -3,7 +3,7 @@
 import torch.utils.data
 import torchvision
 
-from .clevr import CustomCocoDetection
+from .mixed import CustomCocoDetection
 from .clevr import build as build_clevr
 from .clevrref import build as build_clevrref
 from .coco import build as build_coco


### PR DESCRIPTION
datasets/__init__.py tries to import CustomCocoDataset from datasets/clevr.py, but the class is implemented in datasets/mixed.py

It currently crashes during pretraining